### PR TITLE
Task failure recovery strategy configs

### DIFF
--- a/framework/src/main/java/in/org/iudx/adaptor/codegen/TopologyConfig.java
+++ b/framework/src/main/java/in/org/iudx/adaptor/codegen/TopologyConfig.java
@@ -8,6 +8,7 @@ public class TopologyConfig {
   private JSONObject config;
 
   public String name;
+  public JSONObject failureRecoverySpec;
   public JSONObject inputSpec;
   public JSONObject parseSpec;
   public JSONObject deduplicationSpec;
@@ -20,6 +21,7 @@ public class TopologyConfig {
     name = config.getString("name");
     
     // TODO: Run validations
+    failureRecoverySpec = config.getJSONObject("failureRecoverySpec");
     inputSpec = config.getJSONObject("inputSpec");
     parseSpec = config.getJSONObject("parseSpec");
     deduplicationSpec = config.getJSONObject("deduplicationSpec");


### PR DESCRIPTION
https://nightlies.apache.org/flink/flink-docs-stable/docs/ops/state/task_failure_recovery/

- Have made a separate failureRecoverySpec for it, since it makes sense for it to be separate from the other specs. Let me know if it should be changed
- Support for fixed delay and exponential delay strategies, there is also a "failure rate" strategy, which we can support if needed
- Setting the failure rate programmatically requires all the parameters for that failure rate to be specified. For eg., exponential delay has 5 parameters that need to be specified. Currently we require all of them to be specified in the job config. In case we want to use the default values if some are left unspecified, I can add that
- If everything's fine, I'll update the documentations and api specification

Examples:

```
"failureRecoverySpec": {
        "type": "fixed-delay",
        "attempts": 50,
        "delay": 60000
}
```

```
"failureRecoverySpec": {
        "type": "exponential-delay",
        "initial-backoff": 1000,
        "max-backoff": 300000,
	"backoff-multiplier": 2.0,
	"reset-backoff-threshold": 3600000,
	"jitter-factor": 0.1
}
```